### PR TITLE
Fix user name markdown escaping

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -4,5 +4,6 @@ def escape_md(text: str) -> str:
     """Экранирует спецсимволы Markdown."""
     if not isinstance(text, str):
         return text
-    return re.sub(r'([*_\[\]()~`>#+-=|{}.!])', r'\\\1', text)
+    # place '-' at the end of the character class to avoid creating ranges
+    return re.sub(r'([*_\[\]()~`>#+=|{}.!-])', r'\\\1', text)
 


### PR DESCRIPTION
## Summary
- fix regex in `escape_md` to not treat digits as special characters

## Testing
- `python3 -m py_compile *.py`
- `python3 - <<'PY'
from utils import escape_md
print(escape_md('S193627'))
print(escape_md('some*special_chars!'))
PY`