### PR TITLE
Extend admin report with user changes

### DIFF
--- a/admin_report.py
+++ b/admin_report.py
@@ -42,8 +42,10 @@ def _fetch_one(query):
         cur.execute(query)
         return cur.fetchone()
 
-async def send_admin_report(bot: Bot):
+async def send_admin_report(bot: Bot, kicked_users: list[tuple[int, str | None]] | None = None):
     """Формирует текстовый отчёт и отправляет администратору."""
+    if kicked_users is None:
+        kicked_users = []
     try:
         metrics = {k: _fetch_one(q) for k, q in _SQL.items()}
     except Exception as e:
@@ -60,6 +62,8 @@ async def send_admin_report(bot: Bot):
     sub_cnt   = metrics["sub_active"][0]
     active_cnt = metrics["users_active"][0]
 
+    new_users = supabase_client.get_new_users_last_day()
+
     today = datetime.now(timezone.utc).astimezone().strftime("%d.%m.%Y")
 
     
@@ -70,15 +74,25 @@ async def send_admin_report(bot: Bot):
     trx_master     = total_sun / 1_000_000                 # Sun → TRX
 
 
+    new_users_lines = "".join(
+        f"• • {uid} - {uname or 'NoUsername'}\n" for uid, uname in new_users
+    )
+    kicked_lines = "".join(
+        f"• • {uid} - {uname or 'NoUsername'}\n" for uid, uname in kicked_users
+    )
+
     text = (
         f"*Ежедневный отчёт — {today}*\n\n"
         f"• Баланс мастер‑кошелька: {usdt_master:.2f} USDT | {trx_master:.2f} TRX\n\n"
         f"• Всего пользователей в базе: **{users_tot}**\n"
         f"• Всего платежей в базе: **{pays_tot}** на сумму **{usdt_tot:.2f} USDT**\n\n"
         f"• Новых пользователей за текущий месяц: **{users_mon}**\n"
-        f"• Платежей за текущий месяц: **{pays_mon}** на сумму **{usdt_mon:.2f} USDT**\n\n"
-        f"• Новых пользователей за сутки: **{users_day}**\n"
+        f"• Платежей за текущий месяц: **{pays_mon}** на сумму **{usdt_mon:.2f} USDT**\n"
         f"• Платежей за сутки: **{pays_day}** на сумму **{usdt_day:.2f} USDT**\n\n"
+        f"• Новых пользователей за сутки: **{users_day}**\n"
+        f"{new_users_lines if new_users_lines else ''}"
+        f"• Удалено пользователей за сутки: **{len(kicked_users)}**\n"
+        f"{kicked_lines if kicked_lines else ''}\n"
         f"• Всего активных пользователей в базе: **{active_cnt}**\n"
         f"• •  в т.ч. по тестам: **{trial_cnt}**\n"
         f"• •  в т.ч. по подпискам: **{sub_cnt}**"

--- a/daily_tasks.py
+++ b/daily_tasks.py
@@ -23,6 +23,7 @@ async def run_daily_tasks(bot: Bot):
     # Основная ежедневная процедура
     log.info("Running daily tasks…")
     stats = {"trial_warn": 0, "sub_warn": 0, "kicked": 0}
+    kicked_users: list[tuple[int, str | None]] = []
 
     users = supabase_client.get_all_users()          # SELECT * FROM users
     now   = datetime.now(timezone.utc)
@@ -91,6 +92,7 @@ async def run_daily_tasks(bot: Bot):
                     revoke_messages=True,
                 )
                 stats["kicked"] += 1
+                kicked_users.append((tg_id, user.get("username")))
             except Exception as e:
                 log.error("Kick failed for %s: %s", tg_id, e)
 
@@ -100,4 +102,6 @@ async def run_daily_tasks(bot: Bot):
         "Daily tasks finished: trial_warn=%d, sub_warn=%d, kicked=%d",
         stats["trial_warn"], stats["sub_warn"], stats["kicked"],
     )  # выводим статистику в лог
+
+    return stats, kicked_users
 

--- a/main.py
+++ b/main.py
@@ -52,8 +52,8 @@ async def scheduled_daily_job(bot):
     # Тут выполняются периодические напоминания и отправляется статистика
     from daily_tasks import run_daily_tasks
     from admin_report import send_admin_report
-    await run_daily_tasks(bot)
-    await send_admin_report(bot)
+    stats, kicked = await run_daily_tasks(bot)
+    await send_admin_report(bot, kicked)
 
 
 # ---------------------------------------------------------------------------

--- a/supabase_client.py
+++ b/supabase_client.py
@@ -437,6 +437,20 @@ def get_all_users():
         rows = cur.fetchall()
         cols = [d[0] for d in cur.description]
         return [dict(zip(cols, r)) for r in rows]
+
+
+def get_new_users_last_day() -> list[tuple[int, str | None]]:
+    """Returns (telegram_id, username) for users created in the last 24h."""
+    with _get_connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT telegram_id, username
+              FROM users
+             WHERE created_at >= NOW() - interval '1 day'
+             ORDER BY created_at
+            """
+        )
+        return cur.fetchall()
     
 
 def get_pending_payment(user_id: int, deposit_addr: str) -> Optional[int]:


### PR DESCRIPTION
## Summary
- return kicked users list from daily tasks
- provide helper to fetch today's new users
- include lists of added and removed users in admin report
- adjust scheduler to pass kicked user info to report

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687153c220c883228c78bfb55b6b62f4